### PR TITLE
fix: improve code and tests to run on the Stratus blockchain

### DIFF
--- a/contracts/BalanceTracker.sol
+++ b/contracts/BalanceTracker.sol
@@ -18,7 +18,7 @@ contract BalanceTracker is OwnableUpgradeable, IBalanceTracker, IERC20Hook {
     uint256 public constant NEGATIVE_TIME_SHIFT = 3 hours;
 
     /// @notice The address of the hooked token contract
-    address public constant TOKEN = address(0x5FbDB2315678afecb367f032d93F642f64180aa3);
+    address public constant TOKEN = address(0x1b470f79D29839dBCCa9c61c06941E27B3aFbF6d);
 
     /**
      * @notice The day-value pair

--- a/contracts/harnesses/BalanceTrackerHarness.sol
+++ b/contracts/harnesses/BalanceTrackerHarness.sol
@@ -15,6 +15,7 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
     struct BalanceTrackerHarnessState {
         uint256 currentBlockTimestamp;
         bool usingRealBlockTimestamps;
+        bool initialized;
     }
 
     /// @notice The memory slot used to store the contract state
@@ -64,6 +65,7 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
     function setBlockTimestamp(uint256 day, uint256 time) external onlyHarnessAdmin {
         BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
         state.currentBlockTimestamp = day * (24 * 60 * 60) + time;
+        state.initialized = true;
     }
 
     /**
@@ -74,6 +76,7 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
     function setUsingRealBlockTimestamps(bool newValue) external onlyOwner {
         BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
         state.usingRealBlockTimestamps = newValue;
+        state.initialized = true;
     }
 
     /**
@@ -104,7 +107,7 @@ contract BalanceTrackerHarness is BalanceTracker, HarnessAdministrable {
     /// @notice Returns the block timestamp according to the contract settings: the real time or a previously set time
     function _blockTimestamp() internal view virtual override returns (uint256) {
         BalanceTrackerHarnessState storage state = _getBalanceTrackerHarnessState();
-        if (state.usingRealBlockTimestamps) {
+        if (state.usingRealBlockTimestamps || !state.initialized) {
             return super._blockTimestamp();
         } else {
             uint256 blockTimestamp = state.currentBlockTimestamp;

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -11,14 +11,11 @@ export async function getLatestBlockTimestamp(): Promise<number> {
   return getBlockTimestamp("latest");
 }
 
-export async function setBlockTimestampTo(targetTimestamp: number) {
+export async function increaseBlockTimestampTo(targetTimestamp: number) {
   if (network.name === "hardhat") {
-    await time.setNextBlockTimestamp(targetTimestamp);
+    await time.increaseTo(targetTimestamp);
   } else if (network.name === "stratus") {
-    await network.provider.request({
-      method: "evm_setNextBlockTimestamp",
-      params: [targetTimestamp]
-    });
+    await ethers.provider.send("evm_setNextBlockTimestamp", [targetTimestamp]);
     await ethers.provider.send("evm_mine", []);
   } else {
     throw new Error(`Setting block timestamp for the current blockchain is not supported: ${network.name}`);
@@ -30,7 +27,7 @@ export async function increaseBlockTimestamp(increaseInSeconds: number) {
     throw new Error(`The block timestamp increase must be greater than zero, but it equals: ${increaseInSeconds}`);
   }
   const currentTimestamp = await getLatestBlockTimestamp();
-  await setBlockTimestampTo(currentTimestamp + increaseInSeconds);
+  await increaseBlockTimestampTo(currentTimestamp + increaseInSeconds);
 }
 
 export async function proveTx(txResponsePromise: Promise<TransactionResponse>): Promise<TransactionReceipt> {

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -1,4 +1,37 @@
-import { TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+import { ethers, network } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { BlockTag, TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
+
+export async function getBlockTimestamp(blockTag: BlockTag): Promise<number> {
+  const block = await ethers.provider.getBlock(blockTag);
+  return block?.timestamp ?? 0;
+}
+
+export async function getLatestBlockTimestamp(): Promise<number> {
+  return getBlockTimestamp("latest");
+}
+
+export async function setBlockTimestampTo(targetTimestamp: number) {
+  if (network.name === "hardhat") {
+    await time.setNextBlockTimestamp(targetTimestamp);
+  } else if (network.name === "stratus") {
+    await network.provider.request({
+      method: "evm_setNextBlockTimestamp",
+      params: [targetTimestamp]
+    });
+    await ethers.provider.send("evm_mine", []);
+  } else {
+    throw new Error(`Setting block timestamp for the current blockchain is not supported: ${network.name}`);
+  }
+}
+
+export async function increaseBlockTimestamp(increaseInSeconds: number) {
+  if (increaseInSeconds <= 0) {
+    throw new Error(`The block timestamp increase must be greater than zero, but it equals: ${increaseInSeconds}`);
+  }
+  const currentTimestamp = await getLatestBlockTimestamp();
+  await setBlockTimestampTo(currentTimestamp + increaseInSeconds);
+}
 
 export async function proveTx(txResponsePromise: Promise<TransactionResponse>): Promise<TransactionReceipt> {
   const txReceipt = await txResponsePromise;

--- a/test/BalanceTracker.test.ts
+++ b/test/BalanceTracker.test.ts
@@ -1,10 +1,10 @@
 import { ethers, network, upgrades } from "hardhat";
 import { expect } from "chai";
-import { BigNumber, Contract, ContractFactory } from "ethers";
+import { BigNumber, Contract, ContractFactory, Wallet } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
-import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { Block, TransactionReceipt, TransactionResponse } from "@ethersproject/abstract-provider";
-import { proveTx } from "../test-utils/eth";
+import { getLatestBlockTimestamp, increaseBlockTimestamp, proveTx, setBlockTimestampTo } from "../test-utils/eth";
 
 const HOUR_IN_SECONDS = 3600;
 const DAY_IN_SECONDS = 24 * HOUR_IN_SECONDS;
@@ -79,9 +79,9 @@ async function increaseBlockchainTimeToSpecificRelativeDay(relativeDay: number) 
   if (relativeDay < 1) {
     return;
   }
-  const currentTimestampInSeconds: number = await time.latest();
+  const currentTimestampInSeconds: number = await getLatestBlockTimestamp();
   const { secondsOfDay } = toDayAndTime(currentTimestampInSeconds);
-  await time.increase(DAY_IN_SECONDS - secondsOfDay + (relativeDay - 1) * DAY_IN_SECONDS + 1);
+  await increaseBlockTimestamp(DAY_IN_SECONDS - secondsOfDay + (relativeDay - 1) * DAY_IN_SECONDS + 1);
 }
 
 function toBalanceChanges(tokenTransfer: TokenTransfer): BalanceChange[] {
@@ -215,11 +215,53 @@ function defineExpectedDailyBalances(context: TestContext, dailyBalancesRequest:
   return dailyBalances;
 }
 
-async function deployTokenMock(tokenMock: Contract): Promise<Contract> {
+/*
+ * Deploys a mock ERC20 token using a special account to ensure the token contract address
+ * matches a predefined constant `TOKEN` in the `BalanceTracker` contract.
+ *
+ * This function uses a specific private key to deploy the contract. The transaction count of the
+ * special account must be zero to ensure that the first deployed contract matches the `TOKEN`
+ * address constant in `BalanceTracker`.
+ *
+ * If the account has already sent a transaction, the deployment will fail, and the developer
+ * must either reset the network or use a different private key. If a new private key is used, the
+ * developer must update the `TOKEN` constant in `BalanceTracker` to match the new contract address.
+ *
+ * Additionally, the function ensures that the special account has sufficient ETH to cover the
+ * deployment gas costs. If gas is required, it calculates the estimated gas amount and sends
+ * enough ETH from the deployer's account to the special account to cover the deployment.
+ */
+async function deployTokenMockFromSpecialAccount(deployer: SignerWithAddress): Promise<Contract> {
   const tokenMockFactory: ContractFactory = await ethers.getContractFactory("ERC20MockForBalanceTracker");
-  tokenMock = await tokenMockFactory.deploy();
+  const specialPrivateKey = "0x00000000c39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+  const wallet = new Wallet(specialPrivateKey, ethers.provider);
+
+  const txCount = await wallet.getTransactionCount();
+  if (txCount !== 0) {
+    throw new Error(
+      "The special account has already sent transactions on this network. " +
+      "Please reset (and restart if needed) the network or provide a different private key for the special account. " +
+      "If you choose the latter, ensure the 'TOKEN' constant in 'BalanceTracker' is updated with the address " +
+      "of the first contract deployed by the special account."
+    );
+  }
+  const gasPrice: BigNumber = await ethers.provider.getGasPrice();
+
+  if (gasPrice.gt(0)) {
+    const deployTx = tokenMockFactory.connect(wallet).getDeployTransaction();
+    const gasEstimation = await ethers.provider.estimateGas(deployTx);
+    const ethAmount = gasEstimation.mul(gasPrice).mul(2);
+
+    await proveTx(deployer.sendTransaction({
+      to: wallet.address,
+      value: ethAmount.toString()
+    }));
+  }
+
+  const tokenMock = await tokenMockFactory.connect(wallet).deploy();
   await tokenMock.deployed();
-  return tokenMock;
+
+  return tokenMock.connect(deployer);
 }
 
 describe("Contract 'BalanceTracker'", async () => {
@@ -239,20 +281,8 @@ describe("Contract 'BalanceTracker'", async () => {
   let user2: SignerWithAddress;
 
   before(async () => {
-    if (network.name !== "hardhat") {
-      throw new Error(
-        "This tests cannot be run on the network other than Hardhat due to: " +
-        "1. The initial nonce of the contract deployer must be zero at the beginning of each test. " +
-        "2. The ability to change block timestamps for checking the contract under test is required."
-      );
-    }
-    // Resetting the hardhat network to start from scratch and deploy the special token contract mock first
-    await network.provider.request({
-      method: "hardhat_reset",
-      params: []
-    });
     [deployer, attacker, user1, user2] = await ethers.getSigners();
-    tokenMock = await deployTokenMock(tokenMock);
+    tokenMock = await deployTokenMockFromSpecialAccount(deployer);
     await increaseBlockchainTimeToSpecificRelativeDay(1);
     balanceTrackerFactory = await ethers.getContractFactory("BalanceTracker");
   });
@@ -289,7 +319,7 @@ describe("Contract 'BalanceTracker'", async () => {
 
   async function executeTokenTransfers(context: TestContext, transfers: TokenTransfer[]) {
     const { balanceTracker } = context;
-    let previousTransferDay: number = toDayIndex(await time.latest());
+    let previousTransferDay: number = toDayIndex(await getLatestBlockTimestamp());
     for (let i = 0; i < transfers.length; ++i) {
       const transfer: TokenTransfer = transfers[i];
       if (transfer.executionDay < previousTransferDay) {
@@ -494,9 +524,15 @@ describe("Contract 'BalanceTracker'", async () => {
         });
 
         it("The transfer day index is greater than 65536", async () => {
+          // Check the ability to reset the block timestamp for non-Hardhat networks as
+          // the blockchain state cannot be restored using the "loadFixture()" function
+          // and so all other tests might fail because of that.
+          if (network.name !== "hardhat") {
+            await setBlockTimestampTo(0);
+          }
           const context: TestContext = await initTestContext();
 
-          const currentTimestampInSeconds: number = await time.latest();
+          const currentTimestampInSeconds: number = await getLatestBlockTimestamp();
           const currentDay = toDayIndex(currentTimestampInSeconds);
           await increaseBlockchainTimeToSpecificRelativeDay(65537 - currentDay);
 
@@ -508,6 +544,16 @@ describe("Contract 'BalanceTracker'", async () => {
               1
             )
           ).to.be.revertedWithCustomError(context.balanceTracker, REVERT_ERROR_SAFE_CAST_OVERFLOW_UINT16);
+
+          // Reset the block timestamp for non-Hardhat networks as
+          // the blockchain state cannot be restored using the "loadFixture()" function
+          // and so all other tests might fail because of that.
+          if (network.name !== "hardhat") {
+            await setBlockTimestampTo(0);
+          }
+
+          // Reset the blockchain state to ensure further tests run correctly.
+          await initTestContext();
         });
       });
     });


### PR DESCRIPTION
## Main changes
1. The `BalanceTrackerHarness` contract has been improved to use in tests instead of the `BalanceTracker` contract. That is needed to simplify testing of a corner case.
2. The `TOKEN` constant of the `BalanceTracker` has been change to use a separate special account with a unique private key to deploy the single token mock contract at the beginning of the tests.
3. Tests and their utilities have been improved to run on the Stratus network.