### PR TITLE
feat: introduce yield rate tiers

### DIFF
--- a/contracts/v2/YieldStreamerConfiguration.sol
+++ b/contracts/v2/YieldStreamerConfiguration.sol
@@ -62,7 +62,7 @@ abstract contract YieldStreamerConfiguration is
 
         // Add the tiers to the new yield tiered rate
         for (uint256 i = 0; i < tierRates.length; i++) {
-            newYieldRate.tiers.push(YieldRateTier({ rate: tierRates[i].toUint48(), cap: tierCaps[i].toUint64() }));
+            newYieldRate.tiers.push(RateTier({ rate: tierRates[i].toUint48(), cap: tierCaps[i].toUint64() }));
         }
 
         emit YieldStreamer_YieldTieredRateAdded(groupId, effectiveDay, tierRates, tierCaps);
@@ -121,7 +121,7 @@ abstract contract YieldStreamerConfiguration is
         // Update the tiers of the yield tiered rate
         delete rate.tiers;
         for (uint256 i = 0; i < tierRates.length; i++) {
-            rate.tiers.push(YieldRateTier({ rate: tierRates[i].toUint48(), cap: tierCaps[i].toUint64() }));
+            rate.tiers.push(RateTier({ rate: tierRates[i].toUint48(), cap: tierCaps[i].toUint64() }));
         }
 
         emit YieldStreamer_YieldTieredRateUpdated(groupId, itemIndex, effectiveDay, tierRates, tierCaps);

--- a/contracts/v2/YieldStreamerConfiguration.sol
+++ b/contracts/v2/YieldStreamerConfiguration.sol
@@ -62,7 +62,7 @@ abstract contract YieldStreamerConfiguration is
 
         // Add the tiers to the new yield tiered rate
         for (uint256 i = 0; i < tierRates.length; i++) {
-            newYieldRate.tiers.push(YieldRateTier({ rate: tierRates[i].toUint32(), cap: tierCaps[i].toUint64() }));
+            newYieldRate.tiers.push(YieldRateTier({ rate: tierRates[i].toUint48(), cap: tierCaps[i].toUint64() }));
         }
 
         emit YieldStreamer_YieldTieredRateAdded(groupId, effectiveDay, tierRates, tierCaps);
@@ -121,7 +121,7 @@ abstract contract YieldStreamerConfiguration is
         // Update the tiers of the yield tiered rate
         delete rate.tiers;
         for (uint256 i = 0; i < tierRates.length; i++) {
-            rate.tiers.push(YieldRateTier({ rate: tierRates[i].toUint32(), cap: tierCaps[i].toUint64() }));
+            rate.tiers.push(YieldRateTier({ rate: tierRates[i].toUint48(), cap: tierCaps[i].toUint64() }));
         }
 
         emit YieldStreamer_YieldTieredRateUpdated(groupId, itemIndex, effectiveDay, tierRates, tierCaps);

--- a/contracts/v2/YieldStreamerPrimary.sol
+++ b/contracts/v2/YieldStreamerPrimary.sol
@@ -44,7 +44,7 @@ abstract contract YieldStreamerPrimary is
     struct CompoundYieldParams {
         uint256 fromTimestamp;
         uint256 toTimestamp;
-        YieldRateTier[] tiers;
+        RateTier[] tiers;
         uint256 balance;
         uint256 streamYield;
     }
@@ -965,13 +965,13 @@ abstract contract YieldStreamerPrimary is
      */
     function _calculatePartDayYield(
         uint256 amount,
-        YieldRateTier[] memory tiers,
+        RateTier[] memory tiers,
         uint256 elapsedSeconds
     ) private pure returns (uint256) {
         uint256 remainingAmount = amount;
         uint256 totalYield = 0;
         uint256 i = 0;
-        YieldRateTier memory tier;
+        RateTier memory tier;
 
         do {
             if (remainingAmount == 0) {
@@ -999,11 +999,11 @@ abstract contract YieldStreamerPrimary is
      * @param tiers The yield tiers to apply during the calculation period.
      * @return The yield accrued during the full day.
      */
-    function _calculateFullDayYield(uint256 amount, YieldRateTier[] memory tiers) private pure returns (uint256) {
+    function _calculateFullDayYield(uint256 amount, RateTier[] memory tiers) private pure returns (uint256) {
         uint256 remainingAmount = amount;
         uint256 totalYield = 0;
         uint256 i = 0;
-        YieldRateTier memory tier;
+        RateTier memory tier;
 
         do {
             if (remainingAmount == 0) {

--- a/contracts/v2/YieldStreamerStorage.sol
+++ b/contracts/v2/YieldStreamerStorage.sol
@@ -121,7 +121,7 @@ contract YieldStreamerStorage_Primary is IYieldStreamerTypes {
         address feeReceiver;
         mapping(address => Group) groups;
         mapping(address => YieldState) yieldStates;
-        mapping(uint32 => YieldRate[]) yieldRates;
+        mapping(uint32 => YieldTieredRate[]) yieldRates;
     }
 
     /**

--- a/contracts/v2/YieldStreamerStorage.sol
+++ b/contracts/v2/YieldStreamerStorage.sol
@@ -14,13 +14,13 @@ contract YieldStreamerStorage_Constants {
      * @dev The factor used to scale yield rates for precision.
      * For example, a 0.1% rate should be represented as 0.001 * RATE_FACTOR.
      */
-    uint240 public constant RATE_FACTOR = 10 ** 9;
+    uint240 public constant RATE_FACTOR = 10 ** 12;
 
     /**
      * @dev The factor used for rounding yield, fees, and other related values.
      * For example, a value of `12345678` will be rounded up to `12350000` and down to `12340000`.
      */
-    uint256 public constant ROUND_FACTOR = 10000;
+    uint256 public constant ROUND_FACTOR = 10 ** 4;
 
     /**
      * @dev The fee rate used to calculate fee amounts during yield claims.

--- a/contracts/v2/YieldStreamerV2.sol
+++ b/contracts/v2/YieldStreamerV2.sol
@@ -133,7 +133,7 @@ contract YieldStreamerV2 is
     /**
      * @inheritdoc IYieldStreamerPrimary_Functions
      */
-    function getGroupYieldRates(uint256 groupId) external view returns (YieldRate[] memory) {
+    function getGroupYieldRates(uint256 groupId) external view returns (YieldTieredRate[] memory) {
         return _getGroupYieldRates(groupId);
     }
 
@@ -184,9 +184,10 @@ contract YieldStreamerV2 is
     function addYieldRate(
         uint256 groupId, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 effectiveDay,
-        uint256 rateValue
+        uint256[] memory tierRates,
+        uint256[] memory tierCaps
     ) external onlyRole(OWNER_ROLE) {
-        _addYieldRate(groupId, effectiveDay, rateValue);
+        _addYieldRate(groupId, effectiveDay, tierRates, tierCaps);
     }
 
     /**
@@ -196,9 +197,10 @@ contract YieldStreamerV2 is
         uint256 groupId,
         uint256 itemIndex,
         uint256 effectiveDay,
-        uint256 rateValue
+        uint256[] memory tierRates,
+        uint256[] memory tierCaps
     ) external onlyRole(OWNER_ROLE) {
-        _updateYieldRate(groupId, itemIndex, effectiveDay, rateValue);
+        _updateYieldRate(groupId, itemIndex, effectiveDay, tierRates, tierCaps);
     }
 
     /**

--- a/contracts/v2/interfaces/IYieldStreamerConfiguration.sol
+++ b/contracts/v2/interfaces/IYieldStreamerConfiguration.sol
@@ -48,12 +48,14 @@ interface IYieldStreamerConfiguration_Events {
      *
      * @param groupId The ID of the group the yield rate is added to.
      * @param effectiveDay The day index from which the yield rate becomes effective.
-     * @param rateValue The yield rate value added (scaled by RATE_FACTOR).
+     * @param tierRates The yield rate value for each tier (scaled by RATE_FACTOR).
+     * @param tierCaps The balance cap for each tier.
      */
-    event YieldStreamer_YieldRateAdded(
+    event YieldStreamer_YieldTieredRateAdded(
         uint256 indexed groupId, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 effectiveDay,
-        uint256 rateValue
+        uint256[] tierRates,
+        uint256[] tierCaps
     );
 
     /**
@@ -62,13 +64,15 @@ interface IYieldStreamerConfiguration_Events {
      * @param groupId The ID of the group the yield rate is updated for.
      * @param itemIndex The index of the yield rate in the group's rate array.
      * @param effectiveDay The new effective day for the yield rate.
-     * @param rateValue The new yield rate value (scaled by RATE_FACTOR).
+     * @param tierRates The new yield rate value for each tier (scaled by RATE_FACTOR).
+     * @param tierCaps The new balance cap for each tier.
      */
-    event YieldStreamer_YieldRateUpdated(
+    event YieldStreamer_YieldTieredRateUpdated(
         uint256 indexed groupId,
         uint256 itemIndex,
         uint256 effectiveDay,
-        uint256 rateValue
+        uint256[] tierRates,
+        uint256[] tierCaps
     );
 
     /**
@@ -95,9 +99,15 @@ interface IYieldStreamerConfiguration_Functions {
      *
      * @param groupId The ID of the group to which the yield rate is added.
      * @param effectiveDay The day index from which the yield rate becomes effective.
-     * @param rateValue The yield rate value to add (scaled by RATE_FACTOR).
+     * @param tierRates The yield rate value for each tier (scaled by RATE_FACTOR).
+     * @param tierCaps The balance cap for each tier.
      */
-    function addYieldRate(uint256 groupId, uint256 effectiveDay, uint256 rateValue) external;
+    function addYieldRate(
+        uint256 groupId,
+        uint256 effectiveDay,
+        uint256[] memory tierRates,
+        uint256[] memory tierCaps
+    ) external;
 
     /**
      * @dev Updates an existing yield rate for a specific group at a given index.
@@ -105,9 +115,16 @@ interface IYieldStreamerConfiguration_Functions {
      * @param groupId The ID of the group whose yield rate is being updated.
      * @param itemIndex The index of the yield rate to update within the group's rate array.
      * @param effectiveDay The new effective day for the yield rate.
-     * @param rateValue The new yield rate value (scaled by RATE_FACTOR).
+     * @param tierRates The new yield rate value for each tier (scaled by RATE_FACTOR).
+     * @param tierCaps The new balance cap for each tier.
      */
-    function updateYieldRate(uint256 groupId, uint256 itemIndex, uint256 effectiveDay, uint256 rateValue) external;
+    function updateYieldRate(
+        uint256 groupId,
+        uint256 itemIndex,
+        uint256 effectiveDay,
+        uint256[] memory tierRates,
+        uint256[] memory tierCaps
+    ) external;
 
     /**
      * @dev Assigns a group to multiple accounts.

--- a/contracts/v2/interfaces/IYieldStreamerPrimary.sol
+++ b/contracts/v2/interfaces/IYieldStreamerPrimary.sol
@@ -115,9 +115,9 @@ interface IYieldStreamerPrimary_Functions {
      * @dev Retrieves the array of yield rates associated with a specific group ID.
      *
      * @param groupId The ID of the group to query.
-     * @return An array of `YieldRate` structs representing the group's yield rates.
+     * @return An array of `YieldTieredRate` structs representing the group's yield rates.
      */
-    function getGroupYieldRates(uint256 groupId) external view returns (IYieldStreamerTypes.YieldRate[] memory);
+    function getGroupYieldRates(uint256 groupId) external view returns (IYieldStreamerTypes.YieldTieredRate[] memory);
 
     /**
      * @dev Retrieves the group ID to which a specific account is assigned.

--- a/contracts/v2/interfaces/IYieldStreamerTypes.sol
+++ b/contracts/v2/interfaces/IYieldStreamerTypes.sol
@@ -32,17 +32,30 @@ interface IYieldStreamerTypes {
     }
 
     /**
-     * @dev Structure representing a yield rate that becomes effective from a specific day.
-     * Used to determine the yield accrual for accounts based on their assigned group.
+     * @dev Structure representing a yield rate schedule that becomes effective from a specific day.
+     * Contains multiple tiers, each applying a specific rate up to a balance cap.
      *
      * Fields:
-     * - `effectiveDay`: The day index (since Unix epoch) from which this yield rate becomes effective.
-     * - `value`: The yield rate value (scaled by RATE_FACTOR).
+     * - `effectiveDay`: The day index from which this yield rate schedule becomes effective.
+     * - `tiers`: An array of `YieldRateTier` structs defining the rate tiers.
      */
-    struct YieldRate {
+    struct YieldTieredRate {
+        YieldRateTier[] tiers;
         uint16 effectiveDay;
-        uint32 value;
-        // uint208 __reserved; // Reserved for future use until the end of the storage slot.
+        // uint240 __reserved; // Reserved for future use until the end of the storage slot.
+    }
+
+    /**
+     * @dev Structure representing a yield rate tier within a schedule.
+     * Applies a specific rate to a portion of the balance up to a specified cap.
+     *
+     * Fields:
+     * - `rate`: The yield rate value (scaled by RATE_FACTOR).
+     * - `cap`: The maximum balance amount for which this rate applies.
+     */
+    struct YieldRateTier {
+        uint32 rate;
+        uint64 cap;
     }
 
     /**
@@ -96,7 +109,7 @@ interface IYieldStreamerTypes {
      * - `streamYieldBefore`: The stream yield before the accrual period.
      * - `accruedYieldAfter`: The accrued yield after the accrual period.
      * - `streamYieldAfter`: The stream yield after the accrual period.
-     * - `rates`: An array of `YieldRate` structs used during the accrual period.
+     * - `rates`: An array of `YieldTieredRate` structs used during the accrual period.
      * - `results`: An array of `YieldResult` structs detailing yield calculations for sub-periods.
      */
     struct AccruePreview {
@@ -107,7 +120,7 @@ interface IYieldStreamerTypes {
         uint256 accruedYieldBefore;
         uint256 streamYieldAfter;
         uint256 accruedYieldAfter;
-        YieldRate[] rates;
+        YieldTieredRate[] rates;
         YieldResult[] results;
     }
 

--- a/contracts/v2/interfaces/IYieldStreamerTypes.sol
+++ b/contracts/v2/interfaces/IYieldStreamerTypes.sol
@@ -37,10 +37,10 @@ interface IYieldStreamerTypes {
      *
      * Fields:
      * - `effectiveDay`: The day index from which this yield rate schedule becomes effective.
-     * - `tiers`: An array of `YieldRateTier` structs defining the rate tiers.
+     * - `tiers`: An array of `RateTier` structs defining the rate tiers.
      */
     struct YieldTieredRate {
-        YieldRateTier[] tiers;
+        RateTier[] tiers;
         uint16 effectiveDay;
         // uint240 __reserved; // Reserved for future use until the end of the storage slot.
     }
@@ -53,9 +53,10 @@ interface IYieldStreamerTypes {
      * - `rate`: The yield rate value (scaled by RATE_FACTOR).
      * - `cap`: The maximum balance amount for which this rate applies.
      */
-    struct YieldRateTier {
+    struct RateTier {
         uint48 rate;
         uint64 cap;
+        // uint144 __reserved; // Reserved for future use until the end of the storage slot.
     }
 
     /**

--- a/contracts/v2/interfaces/IYieldStreamerTypes.sol
+++ b/contracts/v2/interfaces/IYieldStreamerTypes.sol
@@ -54,7 +54,7 @@ interface IYieldStreamerTypes {
      * - `cap`: The maximum balance amount for which this rate applies.
      */
     struct YieldRateTier {
-        uint32 rate;
+        uint48 rate;
         uint64 cap;
     }
 

--- a/test/v2/YieldStreamer.schedule.test.ts
+++ b/test/v2/YieldStreamer.schedule.test.ts
@@ -5,7 +5,7 @@ import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 // Constants for rate calculations and time units
-const RATE_FACTOR = BigInt(1000000000); // Factor used in yield rate calculations (10^9)
+const RATE_FACTOR = BigInt(1000000000000); // Factor used in yield rate calculations (10^12)
 const DAY = 24 * 60 * 60; // Number of seconds in a day
 const HOUR = 60 * 60; // Number of seconds in an hour
 const NEGATIVE_TIME_SHIFT = 3 * HOUR; // Negative time shift in seconds (3 hours)
@@ -301,7 +301,7 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
         // 40% yield rate
         {
           effectiveDay: 0,
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierRates: [(RATE_FACTOR * BigInt(40000)) / BigInt(100000), (RATE_FACTOR * BigInt(40000)) / BigInt(100000)],
           tierCaps: [BigInt(100), BigInt(0)]
         }
       ];
@@ -428,19 +428,19 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
         // 40% yield rate
         {
           effectiveDay: 0,
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierRates: [(RATE_FACTOR * BigInt(40000)) / BigInt(100000), (RATE_FACTOR * BigInt(40000)) / BigInt(100000)],
           tierCaps: [BigInt(100), BigInt(0)]
         },
         // 80% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 3),
-          tierRates: [(RATE_FACTOR * BigInt(80)) / BigInt(100), (RATE_FACTOR * BigInt(80)) / BigInt(100)],
+          tierRates: [(RATE_FACTOR * BigInt(80000)) / BigInt(100000), (RATE_FACTOR * BigInt(80000)) / BigInt(100000)],
           tierCaps: [BigInt(100), BigInt(0)]
         },
         // 40% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 5),
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierRates: [(RATE_FACTOR * BigInt(40000)) / BigInt(100000), (RATE_FACTOR * BigInt(40000)) / BigInt(100000)],
           tierCaps: [BigInt(100), BigInt(0)]
         }
       ];
@@ -569,7 +569,7 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
         // 40% yield rate
         {
           effectiveDay: 0,
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierRates: [(RATE_FACTOR * BigInt(40000)) / BigInt(100000), (RATE_FACTOR * BigInt(40000)) / BigInt(100000)],
           tierCaps: [BigInt(100), BigInt(0)]
         }
       ];
@@ -696,19 +696,19 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
         // 40% yield rate
         {
           effectiveDay: 0,
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierRates: [(RATE_FACTOR * BigInt(40000)) / BigInt(100000), (RATE_FACTOR * BigInt(40000)) / BigInt(100000)],
           tierCaps: [BigInt(100), BigInt(0)]
         },
         // 80% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 3),
-          tierRates: [(RATE_FACTOR * BigInt(80)) / BigInt(100), (RATE_FACTOR * BigInt(80)) / BigInt(100)],
+          tierRates: [(RATE_FACTOR * BigInt(80000)) / BigInt(100000), (RATE_FACTOR * BigInt(80000)) / BigInt(100000)],
           tierCaps: [BigInt(100), BigInt(0)]
         },
         // 40% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 5),
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierRates: [(RATE_FACTOR * BigInt(40000)) / BigInt(100000), (RATE_FACTOR * BigInt(40000)) / BigInt(100000)],
           tierCaps: [BigInt(100), BigInt(0)]
         }
       ];

--- a/test/v2/YieldStreamer.schedule.test.ts
+++ b/test/v2/YieldStreamer.schedule.test.ts
@@ -301,8 +301,8 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
         // 40% yield rate
         {
           effectiveDay: 0,
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
-          tierCaps: [BigInt(0)]
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(100), BigInt(0)]
         }
       ];
 
@@ -428,20 +428,20 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
         // 40% yield rate
         {
           effectiveDay: 0,
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
-          tierCaps: [BigInt(0)]
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(100), BigInt(0)]
         },
         // 80% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 3),
-          tierRates: [(RATE_FACTOR * BigInt(80)) / BigInt(100)],
-          tierCaps: [BigInt(0)]
+          tierRates: [(RATE_FACTOR * BigInt(80)) / BigInt(100), (RATE_FACTOR * BigInt(80)) / BigInt(100)],
+          tierCaps: [BigInt(100), BigInt(0)]
         },
         // 40% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 5),
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
-          tierCaps: [BigInt(0)]
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(100), BigInt(0)]
         }
       ];
 
@@ -569,8 +569,8 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
         // 40% yield rate
         {
           effectiveDay: 0,
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
-          tierCaps: [BigInt(0)]
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(100), BigInt(0)]
         }
       ];
 
@@ -696,20 +696,20 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
         // 40% yield rate
         {
           effectiveDay: 0,
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
-          tierCaps: [BigInt(0)]
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(100), BigInt(0)]
         },
         // 80% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 3),
-          tierRates: [(RATE_FACTOR * BigInt(80)) / BigInt(100)],
-          tierCaps: [BigInt(0)]
+          tierRates: [(RATE_FACTOR * BigInt(80)) / BigInt(100), (RATE_FACTOR * BigInt(80)) / BigInt(100)],
+          tierCaps: [BigInt(100), BigInt(0)]
         },
         // 40% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 5),
-          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
-          tierCaps: [BigInt(0)]
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100), (RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(100), BigInt(0)]
         }
       ];
 

--- a/test/v2/YieldStreamer.schedule.test.ts
+++ b/test/v2/YieldStreamer.schedule.test.ts
@@ -27,9 +27,10 @@ interface YieldState {
 }
 
 // Interface representing a yield rate change in the contract
-interface YieldRate {
+interface YieldTieredRate {
   effectiveDay: number; // Day when the yield rate becomes effective
-  rateValue: bigint; // Value of the new yield rate (expressed in RATE_FACTOR units)
+  tierRates: bigint[]; // Array of yield rate value for each tier (expressed in RATE_FACTOR units)
+  tierCaps: bigint[]; // Array of balance cap for each tier
 }
 
 /**
@@ -85,16 +86,14 @@ async function testActionSchedule(
   // Iterate over each action in the schedule
   for (const [index, actionItem] of actionItems.entries()) {
     // Calculate the desired internal timestamp for the action based on day and hour offsets
-    const desiredInternalTimestamp =
-      adjustedBlockTime + (actionItem.day - 1) * DAY + actionItem.hour * HOUR;
+    const desiredInternalTimestamp = adjustedBlockTime + (actionItem.day - 1) * DAY + actionItem.hour * HOUR;
 
     // Adjust for NEGATIVE_TIME_SHIFT to set the block.timestamp
     const adjustedTimestamp = desiredInternalTimestamp + NEGATIVE_TIME_SHIFT;
 
     // Ensure the timestamp is strictly greater than the current block timestamp
     const currentBlockTimestamp = Number(await time.latest());
-    const timestampToSet =
-      adjustedTimestamp <= currentBlockTimestamp ? currentBlockTimestamp + 1 : adjustedTimestamp;
+    const timestampToSet = adjustedTimestamp <= currentBlockTimestamp ? currentBlockTimestamp + 1 : adjustedTimestamp;
 
     // Increase the blockchain time to the desired adjusted timestamp
     await time.increaseTo(timestampToSet);
@@ -116,12 +115,8 @@ async function testActionSchedule(
     expectedYieldStates[index].lastUpdateTimestamp = blockTimestamp - NEGATIVE_TIME_SHIFT;
 
     // Assert that the actual yield state matches the expected state
-    expect(contractYieldState.lastUpdateTimestamp).to.equal(
-      expectedYieldStates[index].lastUpdateTimestamp
-    );
-    expect(contractYieldState.lastUpdateBalance).to.equal(
-      expectedYieldStates[index].lastUpdateBalance
-    );
+    expect(contractYieldState.lastUpdateTimestamp).to.equal(expectedYieldStates[index].lastUpdateTimestamp);
+    expect(contractYieldState.lastUpdateBalance).to.equal(expectedYieldStates[index].lastUpdateBalance);
     expect(contractYieldState.accruedYield).to.equal(expectedYieldStates[index].accruedYield);
     expect(contractYieldState.streamYield).to.equal(expectedYieldStates[index].streamYield);
   }
@@ -132,10 +127,10 @@ async function testActionSchedule(
  * @param yieldStreamer The YieldStreamer contract instance.
  * @param yieldRates The list of yield rates to add.
  */
-async function addYieldRates(yieldStreamer: Contract, yieldRates: YieldRate[]): Promise<void> {
+async function addYieldRates(yieldStreamer: Contract, yieldRates: YieldTieredRate[]): Promise<void> {
   const zeroBytes32 = ethers.ZeroHash; // Placeholder for the yield rate ID
   for (const yieldRate of yieldRates) {
-    await yieldStreamer.addYieldRate(zeroBytes32, yieldRate.effectiveDay, yieldRate.rateValue);
+    await yieldStreamer.addYieldRate(zeroBytes32, yieldRate.effectiveDay, yieldRate.tierRates, yieldRate.tierCaps);
   }
 }
 
@@ -302,8 +297,13 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
       ];
 
       // Yield rates to be added to the contract
-      const yieldRates: YieldRate[] = [
-        { effectiveDay: 0, rateValue: (RATE_FACTOR * BigInt(40)) / BigInt(100) } // 40% yield rate
+      const yieldRates: YieldTieredRate[] = [
+        // 40% yield rate
+        {
+          effectiveDay: 0,
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(0)]
+        }
       ];
 
       // Set the initialized state for the user
@@ -424,16 +424,25 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
       ];
 
       // Yield rates to be added to the contract
-      const yieldRates: YieldRate[] = [
-        { effectiveDay: 0, rateValue: (RATE_FACTOR * BigInt(40)) / BigInt(100) }, // 40% yield rate
+      const yieldRates: YieldTieredRate[] = [
+        // 40% yield rate
+        {
+          effectiveDay: 0,
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(0)]
+        },
+        // 80% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 3),
-          rateValue: (RATE_FACTOR * BigInt(80)) / BigInt(100)
-        }, // 80% yield rate
+          tierRates: [(RATE_FACTOR * BigInt(80)) / BigInt(100)],
+          tierCaps: [BigInt(0)]
+        },
+        // 40% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 5),
-          rateValue: (RATE_FACTOR * BigInt(40)) / BigInt(100)
-        } // 40% yield rate
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(0)]
+        }
       ];
 
       // Set the initialized state for the user
@@ -556,8 +565,13 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
       ];
 
       // Yield rates to be added to the contract
-      const yieldRates: YieldRate[] = [
-        { effectiveDay: 0, rateValue: (RATE_FACTOR * BigInt(40)) / BigInt(100) } // 40% yield rate
+      const yieldRates: YieldTieredRate[] = [
+        // 40% yield rate
+        {
+          effectiveDay: 0,
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(0)]
+        }
       ];
 
       // Set the initialized state for the user
@@ -678,16 +692,25 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
       ];
 
       // Yield rates to be added to the contract
-      const yieldRates: YieldRate[] = [
-        { effectiveDay: 0, rateValue: (RATE_FACTOR * BigInt(40)) / BigInt(100) }, // 40% yield rate
+      const yieldRates: YieldTieredRate[] = [
+        // 40% yield rate
+        {
+          effectiveDay: 0,
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(0)]
+        },
+        // 80% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 3),
-          rateValue: (RATE_FACTOR * BigInt(80)) / BigInt(100)
-        }, // 80% yield rate
+          tierRates: [(RATE_FACTOR * BigInt(80)) / BigInt(100)],
+          tierCaps: [BigInt(0)]
+        },
+        // 40% yield rate
         {
           effectiveDay: calculateEffectiveDay(adjustedBlockTime, 5),
-          rateValue: (RATE_FACTOR * BigInt(40)) / BigInt(100)
-        } // 40% yield rate
+          tierRates: [(RATE_FACTOR * BigInt(40)) / BigInt(100)],
+          tierCaps: [BigInt(0)]
+        }
       ];
 
       // Set the initialized state for the user


### PR DESCRIPTION
## Main changes
This pull request updates the yield calculation mechanism by replacing the `YieldRate` with two new structs: `YieldTieredRate` and `RateTier`. This change introduces tiered yield rates with balance caps, allowing different portions of a user's balance to accrue yield at different rates.

### New structures declaration
```Solidity
    /**
     * @dev Structure representing a yield rate schedule that becomes effective from a specific day.
     * Contains multiple tiers, each applying a specific rate up to a balance cap.
     *
     * Fields:
     * - `effectiveDay`: The day index from which this yield rate schedule becomes effective.
     * - `tiers`: An array of `RateTier` structs defining the rate tiers.
     */
    struct YieldTieredRate {
        RateTier[] tiers;
        uint16 effectiveDay;
    }

    /**
     * @dev Structure representing a yield rate tier within a schedule.
     * Applies a specific rate to a portion of the balance up to a specified cap.
     *
     * Fields:
     * - `rate`: The yield rate value (scaled by RATE_FACTOR).
     * - `cap`: The maximum balance amount for which this rate applies.
     */
    struct RateTier {
        uint48 rate;
        uint64 cap;
    }
```

### Yield calculation adjustments:
Yield is now calculated by applying different rates to different segments of a user's balance based on the defined tiers.
The calculation functions have been updated to iterate over the `RateTier` array within each `YieldTieredRate`.

Example:
- Tier 1: Up to 500 BRLC, the yield is calculated at a 5% rate.
- Tier 2: For the next 1000 BRLC, the yield is calculated at a 3% rate.
- Tier 3: A 1% yield rate is applied for the rest of the balance. 

## Test Coverage 
The new changes have yet to be tested.