### PR TITLE
feat: introduce `UUPSExtUpgradeable` base contract

### DIFF
--- a/contracts/v2/YieldStreamerV2.sol
+++ b/contracts/v2/YieldStreamerV2.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.24;
 
-import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { UUPSExtUpgradeable } from "./base/UUPSExtUpgradeable.sol";
 
 import { AccessControlExtUpgradeable } from "./base/AccessControlExtUpgradeable.sol";
 import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
@@ -27,7 +27,7 @@ import { YieldStreamerInitialization } from "./YieldStreamerInitialization.sol";
  * and combines the primary, configuration, and initialization functionalities.
  */
 contract YieldStreamerV2 is
-    UUPSUpgradeable,
+    UUPSExtUpgradeable,
     AccessControlExtUpgradeable,
     PausableExtUpgradeable,
     RescuableUpgradeable,
@@ -308,12 +308,17 @@ contract YieldStreamerV2 is
     // ------------------ Upgrade Authorization ------------------ //
 
     /**
-     * @dev Authorizes the contract upgrade when using UUPS proxy pattern.
-     * Ensures that only an account with the `OWNER_ROLE` can authorize an upgrade.
-     *
-     * @param newImplementation The address of the new contract implementation.
+     * @dev The upgrade validation function for the UUPSExtUpgradeable contract.
+     * @param newImplementation The address of the new implementation.
      */
-    function _authorizeUpgrade(address newImplementation) internal view override onlyRole(OWNER_ROLE) {
-        newImplementation; // Suppresses a compiler warning about the unused variable.
+    function _validateUpgrade(address newImplementation) internal view override onlyRole(OWNER_ROLE) {
+        try IYieldStreamerPrimary(newImplementation).proveYieldStreamer() {} catch {
+            revert YieldStreamer_ImplementationAddressInvalid();
+        }
     }
+
+    /**
+     * @dev Proves the contract is the balance freezer one. A marker function.
+     */
+    function proveYieldStreamer() external pure {}
 }

--- a/contracts/v2/YieldStreamerV2.sol
+++ b/contracts/v2/YieldStreamerV2.sol
@@ -318,7 +318,7 @@ contract YieldStreamerV2 is
     }
 
     /**
-     * @dev Proves the contract is the balance freezer one. A marker function.
+     * @dev Proves the contract is the yield streamer one. A marker function.
      */
     function proveYieldStreamer() external pure {}
 }

--- a/contracts/v2/base/UUPSExtUpgradeable.sol
+++ b/contracts/v2/base/UUPSExtUpgradeable.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+/**
+ * @title UUPSExtUpgradeable base contract
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev Extends the OpenZeppelin's {UUPSUpgradeable} contract by adding additional checks for
+ * the new implementation address.
+ *
+ * This contract is used through inheritance. It introduces the virtual `_validateUpgrade()` function that must be
+ * implemented in the parent contract.
+ */
+abstract contract UUPSExtUpgradeable is UUPSUpgradeable {
+    // ------------------ Errors ---------------------------------- //
+
+    /// @dev Thrown if the provided new implementation address is not a contract.
+    error UUPSExtUpgradeable_ImplementationAddressNotContract();
+
+    /// @dev Thrown if the provided new implementation contract address is zero.
+    error UUPSExtUpgradeable_ImplementationAddressZero();
+
+    // ------------------ Internal functions ---------------------- //
+
+    /**
+     * @dev The upgrade authorization function for UUPSProxy.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _authorizeUpgrade(address newImplementation) internal override {
+        if (newImplementation == address(0)) {
+            revert UUPSExtUpgradeable_ImplementationAddressZero();
+        }
+
+        if (newImplementation.code.length == 0) {
+            revert UUPSExtUpgradeable_ImplementationAddressNotContract();
+        }
+
+        _validateUpgrade(newImplementation);
+    }
+
+    /**
+     * @dev Executes further validation steps of the upgrade including authorization and implementation address checks.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _validateUpgrade(address newImplementation) internal virtual;
+}

--- a/contracts/v2/base/Versionable.sol
+++ b/contracts/v2/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(2, 0, 0);
+        return Version(2, 1, 0);
     }
 }

--- a/contracts/v2/interfaces/IYieldStreamerPrimary.sol
+++ b/contracts/v2/interfaces/IYieldStreamerPrimary.sol
@@ -153,7 +153,7 @@ interface IYieldStreamerPrimary_Functions {
     function blockTimestamp() external view returns (uint256);
 
     /**
-     * @dev Proves the contract is the balance freezer one. A marker function.
+     * @dev Proves the contract is the yield streamer one. A marker function.
      */
     function proveYieldStreamer() external pure;
 }

--- a/contracts/v2/interfaces/IYieldStreamerPrimary.sol
+++ b/contracts/v2/interfaces/IYieldStreamerPrimary.sol
@@ -28,6 +28,9 @@ interface IYieldStreamerPrimary_Errors {
     /// @dev Thrown when the fee receiver address is not configured but required for an operation.
     error YieldStreamer_FeeReceiverNotConfigured();
 
+    /// @dev Thrown if the provided new implementation address is not of a yield streamer contract.
+    error YieldStreamer_ImplementationAddressInvalid();
+
     /// @dev Thrown when an operation is attempted on an account that has not been initialized.
     error YieldStreamer_AccountNotInitialized();
 }
@@ -148,6 +151,11 @@ interface IYieldStreamerPrimary_Functions {
      * @return The current block timestamp.
      */
     function blockTimestamp() external view returns (uint256);
+
+    /**
+     * @dev Proves the contract is the balance freezer one. A marker function.
+     */
+    function proveYieldStreamer() external pure;
 }
 
 /**

--- a/contracts/v2/mocks/base/UUPSExtUpgradableMock.sol
+++ b/contracts/v2/mocks/base/UUPSExtUpgradableMock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { UUPSExtUpgradeable } from "../../base/UUPSExtUpgradeable.sol";
+
+/**
+ * @title UUPSExtUpgradableMock contract
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev An implementation of the {UUPSExtUpgradable} contract for test purposes.
+ */
+contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
+    /// @dev Emitted when the internal `_validateUpgrade()` function is called with the parameters of the function.
+    event MockValidateUpgradeCall(address newImplementation);
+
+    /**
+     * @dev Executes further validation steps of the upgrade including authorization and implementation address checks.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _validateUpgrade(address newImplementation) internal virtual override {
+        emit MockValidateUpgradeCall(newImplementation);
+    }
+}

--- a/test/v2/YieldStreamer.schedule.test.ts
+++ b/test/v2/YieldStreamer.schedule.test.ts
@@ -173,7 +173,7 @@ describe("YieldStreamerV2 - Deposit/Withdraw Simulation Tests", function () {
   let adjustedBlockTime: number;
   const EXPECTED_VERSION: Version = {
     major: 2,
-    minor: 0,
+    minor: 1,
     patch: 0
   };
 

--- a/test/v2/YieldStreamerHarness.test.ts
+++ b/test/v2/YieldStreamerHarness.test.ts
@@ -79,7 +79,7 @@ describe("YieldStreamerV2Harness", function () {
   const harnessAdminRole: string = ethers.id("HARNESS_ADMIN_ROLE");
   const EXPECTED_VERSION: Version = {
     major: 2,
-    minor: 0,
+    minor: 1,
     patch: 0
   };
 

--- a/test/v2/base/UUPSExtUbgradable.test.ts
+++ b/test/v2/base/UUPSExtUbgradable.test.ts
@@ -1,0 +1,70 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { connect } from "../../../test-utils/eth";
+
+const ADDRESS_ZERO = ethers.ZeroAddress;
+
+async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contracts 'UUPSExtUpgradeable'", async () => {
+  // Errors of the lib contracts
+  const REVERT_ERROR_IMPLEMENTATION_ADDRESS_NOT_CONTRACT = "UUPSExtUpgradeable_ImplementationAddressNotContract";
+  const REVERT_ERROR_IMPLEMENTATION_ADDRESS_ZERO = "UUPSExtUpgradeable_ImplementationAddressZero";
+
+  // Events of the contracts under test
+  const EVENT_NAME_MOCK_VALIDATE_UPGRADE_CALL = "MockValidateUpgradeCall";
+
+  let uupsExtensionFactory: ContractFactory;
+  let deployer: HardhatEthersSigner;
+
+  before(async () => {
+    [deployer] = await ethers.getSigners();
+
+    // The contract factory with the explicitly specified deployer account
+    uupsExtensionFactory = await ethers.getContractFactory("UUPSExtUpgradeableMock");
+    uupsExtensionFactory = uupsExtensionFactory.connect(deployer);
+  });
+
+  async function deployContract(): Promise<{ uupsExtension: Contract }> {
+    let uupsExtension: Contract = await upgrades.deployProxy(uupsExtensionFactory, [], { initializer: false });
+    await uupsExtension.waitForDeployment();
+    uupsExtension = connect(uupsExtension, deployer); // Explicitly specifying the initial account
+
+    return { uupsExtension };
+  }
+
+  describe("Function 'upgradeToAndCall()'", async () => {
+    it("Executes as expected", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+
+      const newImplementation = await uupsExtensionFactory.deploy();
+      await newImplementation.waitForDeployment();
+      const newImplementationAddress = await newImplementation.getAddress();
+
+      await expect(uupsExtension.upgradeToAndCall(newImplementationAddress, "0x"))
+        .to.emit(uupsExtension, EVENT_NAME_MOCK_VALIDATE_UPGRADE_CALL)
+        .withArgs(newImplementationAddress);
+    });
+
+    it("Is reverted if the new implementation address is zero", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+      await expect(uupsExtension.upgradeToAndCall(ADDRESS_ZERO, "0x"))
+        .to.be.revertedWithCustomError(uupsExtension, REVERT_ERROR_IMPLEMENTATION_ADDRESS_ZERO);
+    });
+
+    it("Is reverted if the new implementation address is not a contract", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+      await expect(uupsExtension.upgradeToAndCall(deployer.address, "0x"))
+        .to.be.revertedWithCustomError(uupsExtension, REVERT_ERROR_IMPLEMENTATION_ADDRESS_NOT_CONTRACT);
+    });
+  });
+});


### PR DESCRIPTION
## Main changes

1. The new `UUPSExtUpgradeable` contract has been introduced for internal usage through inheritance.
2. The new contract provides additional checks during the upgrade, making the procedure safer.
3. A new marker function named `proveYieldStreamer()` has been added to the `YieldStreamerV2` contract for use in conjunction with the new `UUPSExtUpgradeable` contract. When upgrading, that function ensures that the new implementation of the contract is compatible.

## Versioning 

The version of the `YieldStreamerV2` contract has been changed: `2.0.0` => `2.1.0`.
